### PR TITLE
Fix docs/wrong cmdline.txt path

### DIFF
--- a/docs/server/CONFIGURAZIONE_SERVER.de.md
+++ b/docs/server/CONFIGURAZIONE_SERVER.de.md
@@ -156,12 +156,12 @@ systemd-analyze blame  # Zeigt langsamste Dienste
 
 **2. Kernel-Boot optimieren**
 
-`/boot/cmdline.txt` bearbeiten:
+`/boot/firmware/cmdline.txt` bearbeiten:
 
 ```bash
-sudo nano /boot/cmdline.txt
+sudo nano /boot/firmware/cmdline.txt
 
-# Am Ende der Zeile hinzufügen (alles auf EINER Zeile):
+# Am Ende der Zeile hinzufügen (alles in EINER Zeile):
 quiet splash fastboot noatime nodiratime
 ```
 

--- a/docs/server/CONFIGURAZIONE_SERVER.en.md
+++ b/docs/server/CONFIGURAZIONE_SERVER.en.md
@@ -156,10 +156,10 @@ systemd-analyze blame  # Shows slowest services
 
 **2. Optimize Kernel Boot**
 
-Edit `/boot/cmdline.txt`:
+Edit `/boot/firmware/cmdline.txt`:
 
 ```bash
-sudo nano /boot/cmdline.txt
+sudo nano /boot/firmware/cmdline.txt
 
 # Add at the end of the line (everything on ONE line):
 quiet splash fastboot noatime nodiratime

--- a/docs/server/CONFIGURAZIONE_SERVER.md
+++ b/docs/server/CONFIGURAZIONE_SERVER.md
@@ -156,10 +156,10 @@ systemd-analyze blame  # Mostra servizi più lenti
 
 **2. Ottimizza Boot Kernel**
 
-Modifica `/boot/cmdline.txt`:
+Modifica `/boot/firmware/cmdline.txt`:
 
 ```bash
-sudo nano /boot/cmdline.txt
+sudo nano /boot/firmware/cmdline.txt
 
 # Aggiungi alla fine della riga (tutto su UNA riga):
 quiet splash fastboot noatime nodiratime


### PR DESCRIPTION
I struggle with the Italian PR template, since I don't understand it. Hope it's okay to circumvent it until there's an English one!

Whilst setting up my RPI 4B I noticed a discrepancy in the docs, the location of `/boot/cmdline.txt` has changed to `/boot/firmware/cmdline.txt`.
Content of `/boot/cmdline.txt`:
```
DO NOT EDIT THIS FILE

The file you are looking for has moved to /boot/firmware/cmdline.txt
```
This correlates to the latest Raspberry Pi OS Lite (64-bit).

Hope it helps! :)

PS: I'm still learning git, so hope I did everything correct with branching and naming conventions. All very new to me :)