### PR TITLE
Docs/translation error: cockpit -> cluster

### DIFF
--- a/docs/QUICK_START.de.md
+++ b/docs/QUICK_START.de.md
@@ -29,7 +29,7 @@ node --version && npm --version && git --version
 ```bash
 # Repository klonen
 git clone git@github.com:cyberpandino/cluster.git
-cd cockpit
+cd cluster
 
 # Alle Abhängigkeiten installieren
 npm run install:all

--- a/docs/QUICK_START.en.md
+++ b/docs/QUICK_START.en.md
@@ -29,7 +29,7 @@ node --version && npm --version && git --version
 ```bash
 # Clone repository
 git clone git@github.com:cyberpandino/cluster.git
-cd cockpit
+cd cluster
 
 # Install all dependencies
 npm run install:all


### PR DESCRIPTION
There's a small translation error in the docs where it translated "cluster" to "cockpit" within a code block. Of course that's not an existing directory :).